### PR TITLE
Cleanup Dargon.PortableObjects PofContext exceptions.

### DIFF
--- a/PofContext.cs
+++ b/PofContext.cs
@@ -3,6 +3,8 @@ using System.CodeDom;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using ItzWarty;
 
 namespace Dargon.PortableObjects
 {
@@ -73,6 +75,12 @@ namespace Dargon.PortableObjects
       public void RegisterPortableObjectType(int typeId, Type type) {
          if (typeId < 0)
             throw new ArgumentOutOfRangeException("Negative TypeIDs are reserved for system use.");
+
+         if (type.IsClass) {
+            if (type.GetConstructors().None(ctor => ctor.GetParameters().None())) {
+               throw new MissingMethodException("Type " + type.FullName + " does not provide default constructor for POF instantiation!");
+            }
+         }
 
          if (RegisterPortableObjectTypePrivate(typeId, type)) {
             SetActivator(type, () => (IPortableObject)Activator.CreateInstance(type));

--- a/PofContext.cs
+++ b/PofContext.cs
@@ -66,13 +66,13 @@ namespace Dargon.PortableObjects
             throw new InvalidOperationException("Failed to register reserved portable object type!?");
          }
          SetActivator(type, () => {
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("Attempted to activate a reserved object type - pofwriter/pofreader should handle these explicitly.");
          });
       }
 
       public void RegisterPortableObjectType(int typeId, Type type) {
          if (typeId < 0)
-            throw new InvalidOperationException("Negative TypeIDs are reserved for system use.");
+            throw new ArgumentOutOfRangeException("Negative TypeIDs are reserved for system use.");
 
          if (RegisterPortableObjectTypePrivate(typeId, type)) {
             SetActivator(type, () => (IPortableObject)Activator.CreateInstance(type));
@@ -82,7 +82,7 @@ namespace Dargon.PortableObjects
       public void RegisterPortableObjectType<T>(int typeId, Func<T> ctor)
          where T : IPortableObject {
          if (typeId < 0)
-            throw new InvalidOperationException("Negative TypeIDs are reserved for system use.");
+            throw new ArgumentOutOfRangeException("Negative TypeIDs are reserved for system use.");
 
          if (RegisterPortableObjectTypePrivate(typeId, typeof(T))) {
             SetActivator(typeof(T), () => ctor());

--- a/libdpo.Tests/PofContextTests.cs
+++ b/libdpo.Tests/PofContextTests.cs
@@ -32,33 +32,33 @@ namespace Dargon.PortableObjects.Tests {
          testObj.RegisterPortableObjectType(1, typeof(DummyClass));
          VerifyNoMoreInteractions();
 
-         AssertTrue(Util.IsThrown<DuplicatePofIdException>(() =>
+         Assert.Throws<DuplicatePofIdException>(() =>
             testObj.RegisterPortableObjectType(1, typeof(DummyClass2))
-         ));
+         );
          VerifyNoMoreInteractions();
       }
 
       [Fact]
       public void RegisterPortableObjectType_NegativeIdByType_Throws() {
-         AssertTrue(Util.IsThrown<ArgumentOutOfRangeException>(
+         AssertThrows<ArgumentOutOfRangeException>(
             () => testObj.RegisterPortableObjectType(-1337, typeof(DummyClass))
-         ));
+         );
          VerifyNoMoreInteractions();
       }
 
       [Fact]
       public void RegisterPortableObjectType_NegativeIdByActivator_Throws() {
-         AssertTrue(Util.IsThrown<ArgumentOutOfRangeException>(
+         Assert.Throws<ArgumentOutOfRangeException>(
             () => testObj.RegisterPortableObjectType(-1337, () => new DummyClass())
-         ));
+         );
          VerifyNoMoreInteractions();
       }
 
       [Fact]
       public void RegisterPortableObjectType_ByTypeWithoutParameterlessConstructor_Throws() {
-         AssertTrue(Util.IsThrown<MissingMethodException>(
+         Assert.Throws<MissingMethodException>(
             () => testObj.RegisterPortableObjectType(1337, typeof(DummyClassWithoutDefaultConstructor))
-         ));
+         );
          VerifyNoMoreInteractions();
       }
 
@@ -70,9 +70,9 @@ namespace Dargon.PortableObjects.Tests {
 
       [Fact]
       public void GetTypeIdByType_UnknownType_Throws() {
-         AssertTrue(Util.IsThrown<TypeNotFoundException>(
+         Assert.Throws<TypeNotFoundException>(
             () => testObj.GetTypeIdByType(typeof(DummyClass2))
-         ));
+         );
          VerifyNoMoreInteractions();
       }
 

--- a/libdpo.Tests/PofContextTests.cs
+++ b/libdpo.Tests/PofContextTests.cs
@@ -40,7 +40,7 @@ namespace Dargon.PortableObjects.Tests {
 
       [Fact]
       public void RegisterPortableObjectType_NegativeIdByType_Throws() {
-         AssertTrue(Util.IsThrown<InvalidOperationException>(
+         AssertTrue(Util.IsThrown<ArgumentOutOfRangeException>(
             () => testObj.RegisterPortableObjectType(-1337, typeof(DummyClass))
          ));
          VerifyNoMoreInteractions();
@@ -48,7 +48,7 @@ namespace Dargon.PortableObjects.Tests {
 
       [Fact]
       public void RegisterPortableObjectType_NegativeIdByActivator_Throws() {
-         AssertTrue(Util.IsThrown<InvalidOperationException>(
+         AssertTrue(Util.IsThrown<ArgumentOutOfRangeException>(
             () => testObj.RegisterPortableObjectType(-1337, () => new DummyClass())
          ));
          VerifyNoMoreInteractions();

--- a/libdpo.Tests/PofContextTests.cs
+++ b/libdpo.Tests/PofContextTests.cs
@@ -55,6 +55,14 @@ namespace Dargon.PortableObjects.Tests {
       }
 
       [Fact]
+      public void RegisterPortableObjectType_ByTypeWithoutParameterlessConstructor_Throws() {
+         AssertTrue(Util.IsThrown<MissingMethodException>(
+            () => testObj.RegisterPortableObjectType(1337, typeof(DummyClassWithoutDefaultConstructor))
+         ));
+         VerifyNoMoreInteractions();
+      }
+
+      [Fact]
       public void GetTypeOrNull_UnknownType_ReturnsNull() {
          AssertNull(testObj.GetTypeOrNull(13337777));
          VerifyNoMoreInteractions();
@@ -81,6 +89,18 @@ namespace Dargon.PortableObjects.Tests {
          }
 
          public void Deserialize(IPofReader reader) {
+         }
+      }
+
+      public class DummyClassWithoutDefaultConstructor : IPortableObject {
+         public DummyClassWithoutDefaultConstructor(int throwaway) { }
+
+         public void Serialize(IPofWriter writer) {
+            throw new NotImplementedException();
+         }
+
+         public void Deserialize(IPofReader reader) {
+            throw new NotImplementedException();
          }
       }
    }


### PR DESCRIPTION
libdpo currently waits for clients to try deserializing registered-by-type portable objects before throwing a MethodMissingException. This fix moves that throw to when portable objects are registered (usually at application/test startup).
