### PR TITLE
Expose SlotSourceFactory's CreateFromBinaryReader.

### DIFF
--- a/PofReader.cs
+++ b/PofReader.cs
@@ -11,6 +11,7 @@ namespace Dargon.PortableObjects {
    {
       private readonly IPofContext context;
       private readonly ISlotSource slots;
+      private static readonly SlotSourceFactory slotSourceFactory = new SlotSourceFactoryImpl();
 
       private static readonly Dictionary<Type, Func<BinaryReader, object>> RESERVED_TYPE_READERS = new Dictionary<Type, Func<BinaryReader, object>> {
          {typeof(void), reader => null},
@@ -104,7 +105,7 @@ namespace Dargon.PortableObjects {
             return ReadReservedType(type, reader);
          } else {
             var instance = context.CreateInstance(type);
-            instance.Deserialize(new PofReader(context, SlotSourceFactory.CreateFromBinaryReader(reader)));
+            instance.Deserialize(new PofReader(context, slotSourceFactory.CreateFromBinaryReader(reader)));
             if (instance is SpecialTypes.Base) {
                return ((SpecialTypes.Base)instance).Unwrap();
             } else {

--- a/PofSerializer.cs
+++ b/PofSerializer.cs
@@ -8,6 +8,7 @@ namespace Dargon.PortableObjects
 {
    public class PofSerializer : IPofSerializer {
       private readonly IPofContext context;
+      private static readonly SlotSourceFactoryInternal slotSourceFactory = new SlotSourceFactoryInternalImpl();
 
       public PofSerializer(IPofContext context)
       {
@@ -82,7 +83,7 @@ namespace Dargon.PortableObjects
 
       public object Deserialize(BinaryReader reader, SerializationFlags serializationFlags, Type type) {
          var data = ReadPofFrame(reader, serializationFlags);
-         var pofReader = new PofReader(context, SlotSourceFactory.CreateWithSingleSlot(data));
+         var pofReader = new PofReader(context, slotSourceFactory.CreateWithSingleSlot(data));
          if (serializationFlags.HasFlag(SerializationFlags.Typeless)) {
             return pofReader.ReadObjectTypeless(0, type);
          } else {

--- a/SlotSourceFactory.cs
+++ b/SlotSourceFactory.cs
@@ -1,18 +1,33 @@
 ﻿using System.IO;
 using ItzWarty;
+using ItzWarty.IO;
 
-namespace Dargon.PortableObjects
-{
-   internal static class SlotSourceFactory
-   {
-      public static ISlotSource CreateFromBinaryReader(BinaryReader reader)
-      {
+namespace Dargon.PortableObjects {
+   public interface SlotSourceFactory {
+      ISlotSource CreateFromBinaryReader(BinaryReader reader);
+      ISlotSource CreateFromBinaryReader(IBinaryReader reader);
+   }
+
+   internal interface SlotSourceFactoryInternal {
+      ISlotSource CreateWithSingleSlot(byte[] data);
+   }
+
+   public class SlotSourceFactoryImpl : SlotSourceFactory {
+      public ISlotSource CreateFromBinaryReader(IBinaryReader reader) {
+         return CreateFromBinaryReader(reader.__Reader);
+      }
+
+      public ISlotSource CreateFromBinaryReader(BinaryReader reader) {
          int slotCount = reader.ReadInt32();
          int[] slotLengths = Util.Generate(slotCount, i => reader.ReadInt32());
          var slots = Util.Generate(slotCount, i => reader.ReadBytes(slotLengths[i]));
          return new SlotSource(slots);
       }
+   }
 
-      public static ISlotSource CreateWithSingleSlot(byte[] data) { return new SlotSource(new[] { data }); }
+   internal class SlotSourceFactoryInternalImpl : SlotSourceFactoryImpl, SlotSourceFactoryInternal {
+      public ISlotSource CreateWithSingleSlot(byte[] data) {
+         return new SlotSource(new[] { data });
+      }
    }
 }


### PR DESCRIPTION
Changes a bit ugly to not break compatibility with previous Dargon.PortableObjects. 
